### PR TITLE
update internal transfer in SmartPiggies.sol to fix index bug

### DIFF
--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -306,8 +306,8 @@ function _getERC20Decimals(address _ERC20)
   {
     require(_from == piggies[_tokenId].addresses.holder, "from address is not the owner");
     require(_to != address(0), "to address is zero");
-    _addTokenToOwnedPiggies(_to, _tokenId);
     _removeTokenFromOwnedPiggies(_from, _tokenId);
+    _addTokenToOwnedPiggies(_to, _tokenId);
     piggies[_tokenId].addresses.holder = _to;
   }
 


### PR DESCRIPTION
The order of operations in the _internalTransfer function was creating an indexing error with tracking piggies. It wasn't properly removing the correct id from the ownedPiggies mapping. Removing before adding seems to have addressed this issue. The test for this transfer passes now, but this change needs to be thoroughly tested to make sure it is indeed the fix. The pull request shouldn't change anything in the functionality, yet address the index issue.