### PR TITLE
update reclaimAndBurn in SmartPiggies with _removeToken

### DIFF
--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -375,6 +375,8 @@ function _getERC20Decimals(address _ERC20)
       // return the collateral to sender
       PaymentToken(piggies[_tokenId].addresses.collateralERC).transfer(msg.sender, piggies[_tokenId].uintDetails.collateral);
     }
+    //remove id from index mapping
+    _removeTokenFromOwnedPiggies(piggies[_tokenId].addresses.holder, _tokenId);
     // burn the token (zero out storage fields)
     _resetPiggy(_tokenId);
     return true;


### PR DESCRIPTION
This adds the _reclaimTokenFromOwnedPiggies() to the reclaimAndBurn function to address removing piggy id removal from indexing logic when a piggy is created and then destroyed. Burning passes the unit test with this change.