### PR TITLE
update requestSettlementPrice to account for European style check

### DIFF
--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -578,6 +578,10 @@ function _getERC20Decimals(address _ERC20)
     require(!piggies[_tokenId].flags.hasBeenCleared, "token has already been cleared");  // this is potentially problematic in the case of "garbage data"
     require(_tokenId != 0, "_tokenId cannot be zero");
     require(_oracleFee != 0, "oracle fee cannot be zero");
+    //if Euro require past expiry
+    if (piggies[_tokenId].flags.isEuro) {
+      require(piggies[_tokenId].uintDetails.expiry < block.number);
+    }
     //fetch data from dataResolver contract
     address _dataResolver;
     if (piggies[_tokenId].flags.isEuro || (piggies[_tokenId].uintDetails.expiry < block.number))

--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -580,7 +580,7 @@ function _getERC20Decimals(address _ERC20)
     require(_oracleFee != 0, "oracle fee cannot be zero");
     //if Euro require past expiry
     if (piggies[_tokenId].flags.isEuro) {
-      require(piggies[_tokenId].uintDetails.expiry < block.number);
+      require(piggies[_tokenId].uintDetails.expiry <= block.number);
     }
     //fetch data from dataResolver contract
     address _dataResolver;


### PR DESCRIPTION
It is possible to call `requestSettlementPrice()` before expiry on a European style piggy. This PR adds a check if it is a Euro to require that the current block be past the expiry block. There could be a more efficient way to do this with the current if condition that checks if it is a Euro or past Expiry, but it also may create more logic to do so. This PR passes the unit tests for fail cases for calling `requestSettlementPrice` on a Euro piggy before expiry.