### PR TITLE
Add Events and refactor updateRFP

### DIFF
--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -96,86 +96,86 @@ contract SmartPiggies is ERC165 {
   */
 
   event CreatePiggy(
-      address indexed _from,
-      uint256 indexed _tokenId,
-      bool indexed _RFP
+      address indexed from,
+      uint256 indexed tokenId,
+      bool indexed RFP
   );
 
   event TransferPiggy(
-      address indexed _from,
-      address indexed _to,
-      uint256 indexed _tokenId
+      address indexed from,
+      address indexed to,
+      uint256 indexed tokenId
   );
 
   event UpdateRFP(
-      address indexed _from,
-      uint256 indexed _tokenId,
-      address _collateralERC,
-      address _premiumERC,
-      address _dataResolverNow,
-      address _dataResolverAtExpiry,
-      uint256 _collateral,
-      uint256 _lotSize,
-      uint256 _strikePrice,
-      uint256 _expiry,
-      bool _isEuro,
-      bool _isPut
+      address indexed from,
+      uint256 indexed tokenId,
+      address collateralERC,
+      address premiumERC,
+      address dataResolverNow,
+      address dataResolverAtExpiry,
+      uint256 reqCollateral,
+      uint256 lotSize,
+      uint256 strikePrice,
+      uint256 expiry,
+      bool isEuro,
+      bool isPut
   );
 
   event ReclaimAndBurn(
-      address indexed _from,
-      uint256 indexed _tokenId,
-      bool indexed _RFP
+      address indexed from,
+      uint256 indexed tokenId,
+      bool indexed RFP
   );
 
   event StartAuction(
-      address indexed _from,
-      uint256 indexed _tokenId,
-      uint256 _startPrice,
-      uint256 _reservePrice,
-      uint256 _auctionLength,
-      uint256 _timeStep,
-      uint256 _priceStep
+      address indexed from,
+      uint256 indexed tokenId,
+      uint256 startPrice,
+      uint256 reservePrice,
+      uint256 auctionLength,
+      uint256 timeStep,
+      uint256 priceStep
   );
 
   event EndAuction(
-      address indexed _from,
-      uint256 indexed _tokenId,
-      bool indexed _RFP
+      address indexed from,
+      uint256 indexed tokenId,
+      bool indexed RFP
   );
 
   event SatisfyAuction(
-      address indexed _from,
-      uint256 indexed _tokenId,
-      uint256 _paidPremium,
-      uint256 _change,
-      uint256 _auctionPremium
+      address indexed from,
+      uint256 indexed tokenId,
+      uint256 paidPremium,
+      uint256 change,
+      uint256 auctionPremium
   );
 
   event RequestSettlementPrice(
-      address indexed _feePayer,
-      uint256 indexed _tokenId,
-      uint256 _oracleFee,
-      address _dataResolver
+      address indexed feePayer,
+      uint256 indexed tokenId,
+      uint256 oracleFee,
+      address dataResolver
   );
 
   event OracleReturned(
-      address indexed _resolver,
-      uint256 indexed _tokenId,
-      uint256 indexed _price
+      address indexed resolver,
+      uint256 indexed tokenId,
+      uint256 indexed price
   );
 
   event SettlePiggy(
-     address indexed _from,
-     uint256 indexed _tokenId,
-     uint256 indexed _holderPayout,
-     uint256 _writerPayout
+     address indexed from,
+     uint256 indexed tokenId,
+     uint256 indexed holderPayout,
+     uint256 writerPayout
   );
 
   event ClaimPayout(
-      address indexed _from,
-      uint256 indexed _amount,
-      address indexed _paymentToken
+      address indexed from,
+      uint256 indexed amount,
+      address indexed paymentToken
   );
 
   /**
@@ -410,7 +410,7 @@ function _getERC20Decimals(address _ERC20)
     address _premiumERC,
     address _dataResolverNow,
     address _dataResolverAtExpiry,
-    uint256 _collateral,
+    uint256 _reqCollateral,
     uint256 _lotSize,
     uint256 _strikePrice,
     uint256 _expiry,
@@ -422,6 +422,7 @@ function _getERC20Decimals(address _ERC20)
   {
     require(piggies[_tokenId].addresses.holder == msg.sender, "you must own the RFP to update it");
     require(piggies[_tokenId].flags.isRequest, "you can only update an RFP");
+    uint256 expiryBlock;
     if (_collateralERC != address(0)) {
       piggies[_tokenId].addresses.collateralERC = _collateralERC;
     }
@@ -434,8 +435,8 @@ function _getERC20Decimals(address _ERC20)
     if (_dataResolverAtExpiry != address(0)) {
       piggies[_tokenId].addresses.dataResolverAtExpiry = _dataResolverAtExpiry;
     }
-    if (_collateral != 0) {
-      piggies[_tokenId].uintDetails.collateral = _collateral;
+    if (_reqCollateral != 0) {
+      piggies[_tokenId].uintDetails.reqCollateral = _reqCollateral;
     }
     if (_lotSize != 0) {
       piggies[_tokenId].uintDetails.lotSize = _lotSize;
@@ -445,7 +446,7 @@ function _getERC20Decimals(address _ERC20)
     }
     if (_expiry != 0) {
       // should this redo the expiry calculation? to be consistent w/ how the creation function works ?
-      uint256 expiryBlock = _expiry.add(block.number);
+      expiryBlock = _expiry.add(block.number);
       piggies[_tokenId].uintDetails.expiry = expiryBlock;
     }
     piggies[_tokenId].flags.isEuro = _isEuro;
@@ -458,10 +459,10 @@ function _getERC20Decimals(address _ERC20)
       _premiumERC,
       _dataResolverNow,
       _dataResolverAtExpiry,
-      _collateral,
+      _reqCollateral,
       _lotSize,
       _strikePrice,
-      _expiry.add(block.number),
+      expiryBlock,
       _isEuro,
       _isPut
     );

--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -859,7 +859,7 @@ function _getERC20Decimals(address _ERC20)
      emit SettlePiggy(
        msg.sender,
        _tokenId,
-       ERC20balances[_holder][_collateralERC].add(payout),
+       payout,
        piggies[_tokenId].uintDetails.collateral.sub(payout)
      );
 

--- a/runGanacheFast.sh
+++ b/runGanacheFast.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ganache-cli -g 1100000000 -l 8000000 -h 0.0.0.0

--- a/test/piggycycle-stress.js
+++ b/test/piggycycle-stress.js
@@ -94,7 +94,7 @@ contract ('SmartPiggies', function(accounts) {
         dataResolverNow = resolverInstance.address
         dataResolverAtExpiry = resolverInstance.address
         collateral = web3.utils.toBN(100 * decimals)
-        lotSize = 10
+        lotSize = web3.utils.toBN(10)
         strikePrice = web3.utils.toBN((strike + (i*5)))
         expiry = 500
         isEuro = false
@@ -200,7 +200,7 @@ contract ('SmartPiggies', function(accounts) {
               delta = strikePrice.sub(oraclePrice)
               payout = delta.mul(decimals).mul(lotSize).div(web3.utils.toBN(100))
             }
-            if (payout.gte(collateral)) {
+            if (payout.gt(collateral)) {
               payout = collateral
             }
 

--- a/test/smartpiggies.js
+++ b/test/smartpiggies.js
@@ -175,31 +175,34 @@ contract ('SmartPiggies', function(accounts) {
         {from: owner}
       )
       .then(result => {
-        //console.log(JSON.stringify(result, null, 4));
+        assert.strictEqual(result.logs[0].event, "CreatePiggy", "Event log from create didn't return correct event name")
+        assert.strictEqual(result.logs[0].args._from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args._tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.isNotTrue(result.logs[0].args._RFP, "Event log from create didn't return false for RFP")
+
         return piggyInstance.getDetails(1, {from: owner});
       })
       .then(result => {
-        //console.log(JSON.stringify(result, null, 4));
 
         //check DetailAddresses
-        assert.strictEqual(result[0].writer, owner, "Details should have correct writer address.");
-        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.");
-        assert.strictEqual(result[0].collateralERC, collateralERC, "Details should have correct collateralERC address.");
-        assert.strictEqual(result[0].premiumERC, premiumERC, "Details should have correct premiumERC address.");
-        assert.strictEqual(result[0].dataResolverNow, dataResolverNow, "Details should have correct dataResolverNow address.");
-        assert.strictEqual(result[0].dataResolverAtExpiry, dataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.");
+        assert.strictEqual(result[0].writer, owner, "Details should have correct writer address.")
+        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.")
+        assert.strictEqual(result[0].collateralERC, collateralERC, "Details should have correct collateralERC address.")
+        assert.strictEqual(result[0].premiumERC, premiumERC, "Details should have correct premiumERC address.")
+        assert.strictEqual(result[0].dataResolverNow, dataResolverNow, "Details should have correct dataResolverNow address.")
+        assert.strictEqual(result[0].dataResolverAtExpiry, dataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.")
         //check DetailUints
-        assert.strictEqual(result[1].collateral, collateral.toString(), "Details should have correct collateral amount.");
-        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.");
-        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.");
-        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.");
-        assert.strictEqual(result[1].reqCollateral, "0", "Details should have returned reqCollateral amount of 0.");
-        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.");
+        assert.strictEqual(result[1].collateral, collateral.toString(), "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, "0", "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
         //check BoolFlags
-        assert.isNotTrue(result[2].isRequest, "Details should have returned false for isRequest.");
-        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.");
-        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.");
-        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.");
+        assert.isNotTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
 
         return piggyInstance.getOwnedPiggies(owner, {from: owner})
       })
@@ -213,7 +216,7 @@ contract ('SmartPiggies', function(accounts) {
   });
 
   //Test Create SmartPiggies fail cases
-  describe("Test Failure cases for Creating SmartPiggies tokens", function() {
+  describe("Testinf Failure cases for Creating SmartPiggies tokens", function() {
     before(function() {
       collateralERC = tokenInstance.address
       premiumERC = tokenInstance.address
@@ -411,7 +414,7 @@ contract ('SmartPiggies', function(accounts) {
   });
 
   //Test Create Request For Piggy (RFP)
-  describe("Test RFP functionality", function() {
+  describe("Testing RFP functionality", function() {
 
     it("Should create an RFP token", function() {
       collateralERC = tokenInstance.address
@@ -441,7 +444,11 @@ contract ('SmartPiggies', function(accounts) {
         {from: owner}
       )
       .then(result => {
-        //console.log(JSON.stringify(result, null, 4));
+        assert.strictEqual(result.logs[0].event, "CreatePiggy", "Event log from create didn't return correct event name")
+        assert.strictEqual(result.logs[0].args._from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args._tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.isTrue(result.logs[0].args._RFP, "Event log from create didn't return true for RFP")
+
         return piggyInstance.getDetails(1, {from: owner});
       })
       .then(result => {
@@ -681,7 +688,7 @@ contract ('SmartPiggies', function(accounts) {
   });
 
   //Test transferFrom function
-  describe("Test transfer functionality, Create an American Put piggy and transfer it", function() {
+  describe.only("Test transfer functionality, Create an American Put piggy and transfer it", function() {
 
     it("Should transfer an American Put piggy", function() {
       collateralERC = tokenInstance.address
@@ -727,6 +734,11 @@ contract ('SmartPiggies', function(accounts) {
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "transfer function did not return true")
+        assert.strictEqual(result.logs[0].event, "TransferPiggy", "Event log from create didn't return correct event name")
+        assert.strictEqual(result.logs[0].args._from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args._to, user01, "Event log from create didn't return correct recipient")
+        assert.strictEqual(result.logs[0].args._tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+
         //mint link tokens for user01
         return linkInstance.mint(user01, supply, {from: owner})
       })

--- a/test/smartpiggies.js
+++ b/test/smartpiggies.js
@@ -4453,7 +4453,7 @@ contract ('SmartPiggies', function(accounts) {
             delta = strikePrice.sub(oraclePrice)
             payout = delta.mul(decimals).mul(lotSize).div(web3.utils.toBN(100))
           }
-          if (payout.gte(collateral)) {
+          if (payout.gt(collateral)) {
             payout = collateral
           }
 

--- a/test/smartpiggies.js
+++ b/test/smartpiggies.js
@@ -223,7 +223,7 @@ contract ('SmartPiggies', function(accounts) {
   });
 
   //Test Create SmartPiggies fail cases
-  describe("Testinf Failure cases for Creating SmartPiggies tokens", function() {
+  describe("Testing Failure cases for Creating SmartPiggies tokens", function() {
     before(function() {
       collateralERC = tokenInstance.address
       premiumERC = tokenInstance.address
@@ -3562,7 +3562,7 @@ contract ('SmartPiggies', function(accounts) {
         return piggyInstance.requestSettlementPrice(tokenId, oracleFee, {from: user01})
       })
       .then(result => {
-        assert.isTrue(result.receipt.status, "satisfyAuction did not return true")
+        assert.isTrue(result.receipt.status, "requestSettlementPrice did not return true")
         //Oracle Event
         assert.strictEqual(result.logs[0].event, "OracleReturned", "Event log from oracle didn't return correct event name")
         assert.strictEqual(result.logs[0].args.resolver, dataResolverNow, "Event log from oracle didn't return correct sender")
@@ -4446,8 +4446,6 @@ contract ('SmartPiggies', function(accounts) {
         assert.strictEqual(result.logs[0].args.from, owner, "Event log from settlement didn't return correct sender")
         assert.strictEqual(result.logs[0].args.tokenId.toString(), tokenId.toString(), "Event log from settlement didn't return correct tokenId")
 
-        eventHolderPayout = web3.utils.toBN(result.logs[0].args.holderPayout)
-        eventHolderPayout = web3.utils.toBN(result.logs[0].args.writerPayout)
         // Put payout:
           // if strike > settlement price | payout = strike - settlement price * lot size
           payout = web3.utils.toBN(0)

--- a/test/smartpiggies.js
+++ b/test/smartpiggies.js
@@ -154,11 +154,12 @@ contract ('SmartPiggies', function(accounts) {
       collateral = web3.utils.toBN(100 * decimals)
       lotSize = 10
       strikePrice = 28000
-      expiry = 500
+      expiry = web3.utils.toBN(500)
       isEuro = false
       isPut = true
       isRequest = false
       zeroParam = 0
+      currentBlock = web3.utils.toBN(0)
 
       return piggyInstance.createPiggy(
         collateralERC,
@@ -176,9 +177,14 @@ contract ('SmartPiggies', function(accounts) {
       )
       .then(result => {
         assert.strictEqual(result.logs[0].event, "CreatePiggy", "Event log from create didn't return correct event name")
-        assert.strictEqual(result.logs[0].args._from, owner, "Event log from create didn't return correct sender")
-        assert.strictEqual(result.logs[0].args._tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
-        assert.isNotTrue(result.logs[0].args._RFP, "Event log from create didn't return false for RFP")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.isNotTrue(result.logs[0].args.RFP, "Event log from create didn't return false for RFP")
+
+        web3.eth.getBlockNumberPromise()
+        .then(block => {
+          currentBlock = web3.utils.toBN(block)
+        })
 
         return piggyInstance.getDetails(1, {from: owner});
       })
@@ -195,6 +201,7 @@ contract ('SmartPiggies', function(accounts) {
         assert.strictEqual(result[1].collateral, collateral.toString(), "Details should have correct collateral amount.")
         assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
         assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].expiry, currentBlock.add(expiry).toString(), "Details should have correct strikePrice amount.")
         assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
         assert.strictEqual(result[1].reqCollateral, "0", "Details should have returned reqCollateral amount of 0.")
         assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
@@ -424,7 +431,7 @@ contract ('SmartPiggies', function(accounts) {
       collateral = web3.utils.toBN(100 * decimals)
       lotSize = 10
       strikePrice = 28000
-      expiry = 500
+      expiry = web3.utils.toBN(500)
       isEuro = false
       isPut = true
       isRequest = true //create RFP
@@ -445,9 +452,9 @@ contract ('SmartPiggies', function(accounts) {
       )
       .then(result => {
         assert.strictEqual(result.logs[0].event, "CreatePiggy", "Event log from create didn't return correct event name")
-        assert.strictEqual(result.logs[0].args._from, owner, "Event log from create didn't return correct sender")
-        assert.strictEqual(result.logs[0].args._tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
-        assert.isTrue(result.logs[0].args._RFP, "Event log from create didn't return true for RFP")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.isTrue(result.logs[0].args.RFP, "Event log from create didn't return true for RFP")
 
         return piggyInstance.getDetails(1, {from: owner});
       })
@@ -481,11 +488,856 @@ contract ('SmartPiggies', function(accounts) {
       //end test block
     });
 
+    it("Should update collateralERC address of an RFP token", function() {
+
+      updatedCollateralERC = "0x1230000000000000000000000000000000000000"
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.");
+        return piggyInstance.updateRFP(
+          tokenId,
+          updatedCollateralERC,
+          addr00,
+          addr00,
+          addr00,
+          paramZero,
+          paramZero,
+          paramZero,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, updatedCollateralERC, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), '0', "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), '0', "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailAddresses
+        assert.strictEqual(result[0].writer, addr00, "Details should have correct writer address.")
+        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.")
+        assert.strictEqual(result[0].collateralERC, updatedCollateralERC, "Details should have correct collateralERC address.")
+        assert.strictEqual(result[0].premiumERC, premiumERC, "Details should have correct premiumERC address.")
+        assert.strictEqual(result[0].dataResolverNow, dataResolverNow, "Details should have correct dataResolverNow address.")
+        assert.strictEqual(result[0].dataResolverAtExpiry, dataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.")
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update premiumERC address of an RFP token", function() {
+
+      updatedPremiumERC = "0x1230000000000000000000000000000000000000"
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.");
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          updatedPremiumERC,
+          addr00,
+          addr00,
+          paramZero,
+          paramZero,
+          paramZero,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, updatedPremiumERC, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), '0', "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), '0', "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailAddresses
+        assert.strictEqual(result[0].writer, addr00, "Details should have correct writer address.")
+        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.")
+        assert.strictEqual(result[0].collateralERC, collateralERC, "Details should have correct collateralERC address.")
+        assert.strictEqual(result[0].premiumERC, updatedPremiumERC, "Details should have correct premiumERC address.")
+        assert.strictEqual(result[0].dataResolverNow, dataResolverNow, "Details should have correct dataResolverNow address.")
+        assert.strictEqual(result[0].dataResolverAtExpiry, dataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.")
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update dataResolverNow address of an RFP token", function() {
+
+      updatedDataResolverNow = "0x1230000000000000000000000000000000000000"
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.");
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          updatedDataResolverNow,
+          addr00,
+          paramZero,
+          paramZero,
+          paramZero,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, updatedDataResolverNow, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), '0', "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), '0', "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailAddresses
+        assert.strictEqual(result[0].writer, addr00, "Details should have correct writer address.")
+        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.")
+        assert.strictEqual(result[0].collateralERC, collateralERC, "Details should have correct collateralERC address.")
+        assert.strictEqual(result[0].premiumERC, premiumERC, "Details should have correct premiumERC address.")
+        assert.strictEqual(result[0].dataResolverNow, updatedDataResolverNow, "Details should have correct dataResolverNow address.")
+        assert.strictEqual(result[0].dataResolverAtExpiry, dataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.")
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update dataResolverAtExpiry address of an RFP token", function() {
+
+      updatedDataResolverAtExpiry = "0x1230000000000000000000000000000000000000"
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.");
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          updatedDataResolverAtExpiry,
+          paramZero,
+          paramZero,
+          paramZero,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, updatedDataResolverAtExpiry, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), '0', "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), '0', "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailAddresses
+        assert.strictEqual(result[0].writer, addr00, "Details should have correct writer address.")
+        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.")
+        assert.strictEqual(result[0].collateralERC, collateralERC, "Details should have correct collateralERC address.")
+        assert.strictEqual(result[0].premiumERC, premiumERC, "Details should have correct premiumERC address.")
+        assert.strictEqual(result[0].dataResolverNow, dataResolverNow, "Details should have correct dataResolverNow address.")
+        assert.strictEqual(result[0].dataResolverAtExpiry, updatedDataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.")
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update collateral of an RFP token", function() {
+
+      updatedCollateral = web3.utils.toBN(200 * decimals)
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have correct reqCollaterial amount.");
+
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          addr00,
+          updatedCollateral,
+          paramZero,
+          paramZero,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), updatedCollateral.toString(), "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), '0', "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailAddresses
+        assert.strictEqual(result[0].writer, addr00, "Details should have correct writer address.")
+        assert.strictEqual(result[0].holder, owner, "Details should have correct holder address.")
+        assert.strictEqual(result[0].collateralERC, collateralERC, "Details should have correct collateralERC address.")
+        assert.strictEqual(result[0].premiumERC, premiumERC, "Details should have correct premiumERC address.")
+        assert.strictEqual(result[0].dataResolverNow, dataResolverNow, "Details should have correct dataResolverNow address.")
+        assert.strictEqual(result[0].dataResolverAtExpiry, dataResolverAtExpiry, "Details should have correct dataResolverAtExpiry address.")
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, updatedCollateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update lotSize of an RFP token", function() {
+
+      updatedLotSize = 100
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          addr00,
+          paramZero,
+          updatedLotSize,
+          paramZero,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC.toString(), addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC.toString(), addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow.toString(), addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry.toString(), addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), '0', "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), updatedLotSize.toString(), "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), '0', "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.isTrue(result[2].isRequest, "Details should have returned true for isRequest.")
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, updatedLotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update strikePrice of an RFP token", function() {
+
+      updatedStrikePrice = 29000
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct lotSize amount.");
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          addr00,
+          paramZero,
+          paramZero,
+          updatedStrikePrice,
+          paramZero,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), "0", "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), updatedStrikePrice.toString(), "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, updatedStrikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update expiry of an RFP token", function() {
+
+      updatedExpiry = web3.utils.toBN(100) // add 100 blocks to the expiry block
+      paramZero = 0
+      currentBlock = web3.utils.toBN(0)
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+
+        web3.eth.getBlockNumberPromise()
+        .then(block => {
+          currentBlock = web3.utils.toBN(block) // will be mined in next block
+        })
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.strictEqual(result[1].expiry, currentBlock.add(expiry).toString(), "Details should have correct lotSize amount.");
+
+        web3.eth.getBlockNumberPromise()
+        .then(block => {
+          currentBlock = web3.utils.toBN(block).add(web3.utils.toBN(1)) // will be mined in next block
+        })
+
+        assert.strictEqual(result[1].expiry, currentBlock.add(expiry).toString(), "Details should have correct lotSize amount.");
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          addr00,
+          paramZero,
+          paramZero,
+          paramZero,
+          updatedExpiry,
+          isEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), "0", "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), "0", "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), currentBlock.add(updatedExpiry).toString(), "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].expiry, currentBlock.add(updatedExpiry).toString(), "Details should have correct expiry amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update Style of an RFP token", function() {
+
+      updatedIsEuro = true
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.isNotTrue(result[2].isEuro, "Details should have returned false for isEuro.")
+
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          addr00,
+          paramZero,
+          paramZero,
+          paramZero,
+          paramZero,
+          updatedIsEuro,
+          isPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), "0", "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), "0", "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isTrue(result.logs[0].args.isEuro, "updateRFP did not return true for isEuro")
+        assert.isTrue(result.logs[0].args.isPut, "updateRFP did not return true for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isTrue(result[2].isEuro, "Details should have returned true for isEuro.")
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
+    it("Should update Direction of an RFP token", function() {
+
+      updatedIsPut = false
+      paramZero = 0
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "Create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        tokenId = result
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        assert.isTrue(result[2].isPut, "Details should have returned true for isPut.")
+
+        return piggyInstance.updateRFP(
+          tokenId,
+          addr00,
+          addr00,
+          addr00,
+          addr00,
+          paramZero,
+          paramZero,
+          paramZero,
+          paramZero,
+          isEuro,
+          updatedIsPut,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "updateRFP did not return true")
+        assert.strictEqual(result.logs[0].event, "UpdateRFP", "Event log from update didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from update didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from update didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.collateralERC, addr00, "Event log from update didn't return correct collaterialERC")
+        assert.strictEqual(result.logs[0].args.premiumERC, addr00, "Event log from update didn't return correct premiumERC")
+        assert.strictEqual(result.logs[0].args.dataResolverNow, addr00, "Event log from update didn't return correct dataResolverNow")
+        assert.strictEqual(result.logs[0].args.dataResolverAtExpiry, addr00, "Event log from update didn't return correct dataResolverAtExpiry")
+        assert.strictEqual(result.logs[0].args.reqCollateral.toString(), "0", "Event log from update didn't return correct collateral")
+        assert.strictEqual(result.logs[0].args.lotSize.toString(), "0", "Event log from update didn't return correct lotSize")
+        assert.strictEqual(result.logs[0].args.strikePrice.toString(), "0", "Event log from update didn't return correct strikePrice")
+        assert.strictEqual(result.logs[0].args.expiry.toString(), "0", "Event log from update didn't return correct expiry")
+        assert.isNotTrue(result.logs[0].args.isEuro, "updateRFP did not return false for isEuro")
+        assert.isNotTrue(result.logs[0].args.isPut, "updateRFP did not return false for isPut")
+
+        return piggyInstance.getDetails(tokenId, {from: owner});
+      })
+      .then(result => {
+        //check DetailUints
+        assert.strictEqual(result[1].collateral, "0", "Details should have correct collateral amount.")
+        assert.strictEqual(result[1].lotSize, lotSize.toString(), "Details should have correct lotSize amount.")
+        assert.strictEqual(result[1].strikePrice, strikePrice.toString(), "Details should have correct strikePrice amount.")
+        assert.strictEqual(result[1].settlementPrice, "0", "Details should have returned settlementPrice amount of 0.")
+        assert.strictEqual(result[1].reqCollateral, collateral.toString(), "Details should have returned reqCollateral amount of 0.")
+        assert.strictEqual(result[1].collateralDecimals, "18", "Details should have returned collateralDecimals amount of 18.")
+        //check BoolFlags
+        assert.isTrue(result[2].isRequest, "Details should have returned false for isRequest.")
+        assert.isNotTrue(result[2].isEuro, "Details should have returned true for isEuro.")
+        assert.isNotTrue(result[2].isPut, "Details should have returned false for isPut.")
+        assert.isNotTrue(result[2].hasBeenCleared, "Details should have returned false for hasBeenCleared.")
+      })
+      //end test block
+    });
+
   //end describe RFP block
   });
 
   //Test American Put
-  describe("Test American Put functionality", function() {
+  describe("Testing American Put functionality", function() {
 
     it("Should create an American Put piggy", function() {
       collateralERC = tokenInstance.address
@@ -688,7 +1540,7 @@ contract ('SmartPiggies', function(accounts) {
   });
 
   //Test transferFrom function
-  describe.only("Test transfer functionality, Create an American Put piggy and transfer it", function() {
+  describe("Testing Transfer functionality, Create an American Put piggy and transfer it", function() {
 
     it("Should transfer an American Put piggy", function() {
       collateralERC = tokenInstance.address
@@ -735,9 +1587,9 @@ contract ('SmartPiggies', function(accounts) {
       .then(result => {
         assert.isTrue(result.receipt.status, "transfer function did not return true")
         assert.strictEqual(result.logs[0].event, "TransferPiggy", "Event log from create didn't return correct event name")
-        assert.strictEqual(result.logs[0].args._from, owner, "Event log from create didn't return correct sender")
-        assert.strictEqual(result.logs[0].args._to, user01, "Event log from create didn't return correct recipient")
-        assert.strictEqual(result.logs[0].args._tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.to, user01, "Event log from create didn't return correct recipient")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
 
         //mint link tokens for user01
         return linkInstance.mint(user01, supply, {from: owner})
@@ -1020,30 +1872,34 @@ contract ('SmartPiggies', function(accounts) {
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "startAuction did not return true")
-        return tokenInstance.mint(user01, startPrice, {from: owner})
-      })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "mint did not return true")
-        return tokenInstance.approve(piggyInstance.address, startPrice, {from: user01})
-      })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "approve did not return true")
-        return tokenInstance.balanceOf(user01, {from: user01})
-      })
-      .then(balance => {
-        balanceBefore = balance
-        return piggyInstance.getAuctionDetails(tokenId, {from: owner})
-      })
-      .then(result => {
-        expiryBlock = result.expiryBlock
+        //test events
+        assert.strictEqual(result.logs[0].event, "StartAuction", "Event log from create didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.startPrice.toString(), startPrice.toString(), "Event log from create didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.reservePrice.toString(), reservePrice.toString(), "Event log from create didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.auctionLength.toString(), auctionLength.toString(), "Event log from create didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.timeStep.toString(), timeStep.toString(), "Event log from create didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.priceStep.toString(), priceStep.toString(), "Event log from create didn't return correct tokenId")
 
-        assert.strictEqual(result.startBlock.toString(), startBlock.toString(), "getAuctionDetails did not return the correct start block")
-        assert.strictEqual(result.expiryBlock.toString(), startBlock.add(auctionLength).toString(), "getAuctionDetails did not return the correct expiry block")
-        assert.strictEqual(result.startPrice.toString(), startPrice.toString(), "getAuctionDetails did not return the correct start price")
-        assert.strictEqual(result.timeStep.toString(), timeStep.toString(), "getAuctionDetails did not return the correct time step")
-        assert.strictEqual(result.priceStep.toString(), priceStep.toString(), "getAuctionDetails did not return the correct price step")
-        assert.isTrue(result.auctionActive, "getAuctionDetails did not return true for auction active")
-        assert.isNotTrue(result.satisfyInProgress, "getAuctionDetails did not return false for satisfyInProgress")
+        return sequentialPromise([
+          () => Promise.resolve(tokenInstance.mint(user01, startPrice, {from: owner})),
+          () => Promise.resolve(tokenInstance.approve(piggyInstance.address, startPrice, {from: user01})),
+          () => Promise.resolve(tokenInstance.balanceOf(user01, {from: user01})),
+          () => Promise.resolve(piggyInstance.getAuctionDetails(tokenId, {from: owner})),
+        ])
+      })
+      .then(result => {
+        balanceBefore = result[2]
+        expiryBlock = result[3].expiryBlock
+
+        assert.strictEqual(result[3].startBlock.toString(), startBlock.toString(), "getAuctionDetails did not return the correct start block")
+        assert.strictEqual(result[3].expiryBlock.toString(), startBlock.add(auctionLength).toString(), "getAuctionDetails did not return the correct expiry block")
+        assert.strictEqual(result[3].startPrice.toString(), startPrice.toString(), "getAuctionDetails did not return the correct start price")
+        assert.strictEqual(result[3].timeStep.toString(), timeStep.toString(), "getAuctionDetails did not return the correct time step")
+        assert.strictEqual(result[3].priceStep.toString(), priceStep.toString(), "getAuctionDetails did not return the correct price step")
+        assert.isTrue(result[3].auctionActive, "getAuctionDetails did not return true for auction active")
+        assert.isNotTrue(result[3].satisfyInProgress, "getAuctionDetails did not return false for satisfyInProgress")
 
         return piggyInstance.satisfyAuction(tokenId, {from: user01})
       })
@@ -1829,6 +2685,11 @@ contract ('SmartPiggies', function(accounts) {
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "endAuction did not return true")
+        assert.strictEqual(result.logs[0].event, "EndAuction", "Event log from create didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from create didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from create didn't return correct tokenId")
+        assert.isNotTrue(result.logs[0].args.RFP, "Event log from create didn't return false for RFP")
+
         return piggyInstance.getAuctionDetails(tokenId, {from: owner})
       })
       .then(result => {
@@ -2100,23 +2961,17 @@ contract ('SmartPiggies', function(accounts) {
           {from: owner}
         )
       })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "startAuction did not return true")
-        return tokenInstance.mint(user01, collateral, {from: owner})
-      })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "mint did not return true")
-        return tokenInstance.approve(piggyInstance.address, collateral, {from: user01})
-      })
       .then(() => {
         //get balances
         return sequentialPromise([
+          () => Promise.resolve(tokenInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(tokenInstance.approve(piggyInstance.address, collateral, {from: user01})),
           () => Promise.resolve(tokenInstance.balanceOf(owner, {from: owner})),
           () => Promise.resolve(tokenInstance.balanceOf(user01, {from: owner}))
         ])
         .then(result => {
-          ownerBalanceBefore = web3.utils.toBN(result[0])
-          userBalanceBefore = web3.utils.toBN(result[1])
+          ownerBalanceBefore = web3.utils.toBN(result[2])
+          userBalanceBefore = web3.utils.toBN(result[3])
         })
       })
       .then(() => {
@@ -2129,8 +2984,25 @@ contract ('SmartPiggies', function(accounts) {
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "satisfyAuction did not return true")
+        //test events
+        //Transfer Event
+        assert.strictEqual(result.logs[0].event, "TransferPiggy", "Event log from satisfy didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from transfer didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.to, user01, "Event log from transfer didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from transfer didn't return correct tokenId")
+        //Satisfy Event
+        assert.strictEqual(result.logs[1].event, "SatisfyAuction", "Event log from satisfy didn't return correct event name")
+        assert.strictEqual(result.logs[1].args.from, user01, "Event log from satisfy didn't return correct sender")
+        assert.strictEqual(result.logs[1].args.tokenId.toString(), "1", "Event log from satisfy didn't return correct tokenId")
+        //assert.strictEqual(result.logs[0].args.paidPremium.toString(), startPrice.toString(), "Event log from create didn't return correct tokenId")
+        //assert.strictEqual(result.logs[0].args.change.toString(), reservePrice.toString(), "Event log from create didn't return correct tokenId")
+        //assert.strictEqual(result.logs[0].args.auctionPremium.toString(), auctionLength.toString(), "Event log from create didn't return correct tokenId")
 
-        web3.eth.getBlockNumberPromise()
+        eventPricePaid = web3.utils.toBN(result.logs[1].args.paidPremium)
+        eventChangePaid = web3.utils.toBN(result.logs[1].args.change)
+        eventAuctionPremium = web3.utils.toBN(result.logs[1].args.auctionPremium)
+
+        return web3.eth.getBlockNumberPromise()
         .then(blockNumber => {
           if (blockNumber < expiryBlock) {
             currentBlock = web3.utils.toBN(blockNumber)
@@ -2142,6 +3014,10 @@ contract ('SmartPiggies', function(accounts) {
         })
       })
       .then(() => {
+        assert.strictEqual(eventPricePaid.toString(), auctionPrice.toString(), "Event log from satisfy didn't return correct price paid")
+        assert.strictEqual(eventChangePaid.toString(), "0", "Event log from satisfy didn't return correct change paid")
+        assert.strictEqual(eventAuctionPremium.toString(), auctionPrice.toString(), "Event log from satisfy didn't return correct auction premium")
+
         return piggyInstance.getDetails(tokenId, {from: owner})
       })
       .then(result => {
@@ -2226,23 +3102,17 @@ contract ('SmartPiggies', function(accounts) {
           {from: owner}
         )
       })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "startAuction did not return true")
-        return tokenInstance.mint(user01, collateral, {from: owner})
-      })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "mint did not return true")
-        return tokenInstance.approve(piggyInstance.address, collateral, {from: user01})
-      })
       .then(() => {
         //get balances
         return sequentialPromise([
+          () => Promise.resolve(tokenInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(tokenInstance.approve(piggyInstance.address, collateral, {from: user01})),
           () => Promise.resolve(tokenInstance.balanceOf(owner, {from: owner})),
           () => Promise.resolve(tokenInstance.balanceOf(user01, {from: owner}))
         ])
         .then(result => {
-          ownerBalanceBefore = web3.utils.toBN(result[0])
-          userBalanceBefore = web3.utils.toBN(result[1])
+          ownerBalanceBefore = web3.utils.toBN(result[2])
+          userBalanceBefore = web3.utils.toBN(result[3])
         })
       })
       .then(() => {
@@ -2255,8 +3125,16 @@ contract ('SmartPiggies', function(accounts) {
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "satisfyAuction did not return true")
+        //Satisfy Event
+        assert.strictEqual(result.logs[0].event, "SatisfyAuction", "Event log from satisfy didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, user01, "Event log from satisfy didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), "1", "Event log from satisfy didn't return correct tokenId")
 
-        web3.eth.getBlockNumberPromise()
+        eventPricePaid = web3.utils.toBN(result.logs[0].args.paidPremium)
+        eventChangePaid = web3.utils.toBN(result.logs[0].args.change)
+        eventAuctionPremium = web3.utils.toBN(result.logs[0].args.auctionPremium)
+
+        return web3.eth.getBlockNumberPromise()
         .then(blockNumber => {
           if (blockNumber < expiryBlock) {
             currentBlock = web3.utils.toBN(blockNumber)
@@ -2268,6 +3146,10 @@ contract ('SmartPiggies', function(accounts) {
         })
       })
       .then(() => {
+        assert.strictEqual(eventPricePaid.toString(), auctionPrice.toString(), "Event log from satisfy didn't return correct price paid")
+        assert.strictEqual(eventChangePaid.toString(), reservePrice.sub(auctionPrice).toString(), "Event log from satisfy didn't return correct change paid")
+        assert.strictEqual(eventAuctionPremium.toString(), auctionPrice.toString(), "Event log from satisfy didn't return correct premium")
+
         return piggyInstance.getDetails(tokenId, {from: owner})
       })
       .then(result => {
@@ -2665,28 +3547,35 @@ contract ('SmartPiggies', function(accounts) {
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "startAuction did not return true")
-        return tokenInstance.mint(user01, collateral, {from: owner})
+
+        return sequentialPromise([
+          () => Promise.resolve(tokenInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(tokenInstance.approve(piggyInstance.address, collateral, {from: user01})),
+          () => Promise.resolve(piggyInstance.satisfyAuction(tokenId, {from: user01})),
+          () => Promise.resolve(linkInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(linkInstance.approve(resolverInstance.address, collateral, {from: user01})),
+        ])
       })
       .then(result => {
-        assert.isTrue(result.receipt.status, "mint did not return true")
-        return tokenInstance.approve(piggyInstance.address, collateral, {from: user01})
-      })
-      .then(() => {
-        return piggyInstance.satisfyAuction(tokenId, {from: user01})
-      })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "satisfyAuction did not return true")
-        return linkInstance.mint(user01, collateral, {from: owner})
-      })
-      .then(result => {
-        assert.isTrue(result.receipt.status, "mint did not return true")
-        return linkInstance.approve(resolverInstance.address, collateral, {from: user01})
-      })
-      .then(result => {
+        assert.isTrue(result[2].receipt.status, "satisfyAuction did not return true")
+
         return piggyInstance.requestSettlementPrice(tokenId, oracleFee, {from: user01})
       })
       .then(result => {
-        assert.isTrue(result.receipt.status, "requestSettlementPrice did not return true")
+        assert.isTrue(result.receipt.status, "satisfyAuction did not return true")
+        //Oracle Event
+        assert.strictEqual(result.logs[0].event, "OracleReturned", "Event log from oracle didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.resolver, dataResolverNow, "Event log from oracle didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), tokenId.toString(), "Event log from oracle didn't return correct tokenId")
+        assert.strictEqual(result.logs[0].args.price.toString(), oraclePrice.toString(), "Event log from oracle didn't return correct tokenId")
+
+        //Satisfy Event
+        assert.strictEqual(result.logs[1].event, "RequestSettlementPrice", "Event log from request didn't return correct event name")
+        assert.strictEqual(result.logs[1].args.feePayer, user01, "Event log from request didn't return correct sender")
+        assert.strictEqual(result.logs[1].args.tokenId.toString(), tokenId.toString(), "Event log from request didn't return correct tokenId")
+        assert.strictEqual(result.logs[1].args.oracleFee.toString(), oracleFee.toString(), "Event log from request didn't return correct tokenId")
+        assert.strictEqual(result.logs[1].args.dataResolver.toString(), dataResolverNow, "Event log from request didn't return correct tokenId")
+
         return piggyInstance.getDetails(tokenId, {from: owner})
       })
       .then(result => {
@@ -3385,7 +4274,7 @@ contract ('SmartPiggies', function(accounts) {
   //end describe Clearing block
   })
 
-  describe("Testing Settle functionality for American style piggies", function() {
+  describe.only("Testing Settle functionality for American style piggies", function() {
 
     it("Should settle an American Put piggy with payout to writer", function() {
       collateralERC = tokenInstance.address
@@ -3476,6 +4365,104 @@ contract ('SmartPiggies', function(accounts) {
         //put calculation for holder = payout
         assert.strictEqual(result[8].toString(), payout.toString(), "User balance did not update correctly")
         assert.strictEqual(result[8].toString(), "0", "Owner balance did not return 0")
+      })
+      //end test block
+    });
+
+    it("Should emit correct Settle Event when writer is paid full", function() {
+      collateralERC = tokenInstance.address
+      premiumERC = tokenInstance.address
+      dataResolverNow = resolverInstance.address
+      dataResolverAtExpiry = resolverInstance.address
+      collateral = web3.utils.toBN(100 * decimals)
+      lotSize = web3.utils.toBN(100)
+      strikePrice = web3.utils.toBN(26900)
+      expiry = 5000
+      isEuro = false
+      isPut = true
+      isRequest = false
+
+      startPrice = web3.utils.toBN(10000)
+      reservePrice = web3.utils.toBN(100)
+      auctionLength = 100
+      timeStep = web3.utils.toBN(1)
+      priceStep = web3.utils.toBN(100)
+
+      startBlock = web3.utils.toBN(0)
+      auctionPrice = web3.utils.toBN(0)
+
+      oracleFee = web3.utils.toBN('1000000000000000000')
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        //use last tokenId created
+        tokenId = result
+        return piggyInstance.startAuction(
+          tokenId,
+          startPrice,
+          reservePrice,
+          auctionLength,
+          timeStep,
+          priceStep,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "startAuction did not return true")
+
+        return sequentialPromise([
+          () => Promise.resolve(tokenInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(tokenInstance.approve(piggyInstance.address, collateral, {from: user01})),
+          () => Promise.resolve(piggyInstance.satisfyAuction(tokenId, {from: user01})),
+          () => Promise.resolve(linkInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(linkInstance.approve(resolverInstance.address, collateral, {from: user01})),
+          () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenId, oracleFee, {from: user01})),
+        ])
+      })
+      .then(() => {
+        return piggyInstance.settlePiggy(tokenId, {from: owner})
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "settlePiggy did not return true")
+        //Settle Event
+        assert.strictEqual(result.logs[0].event, "SettlePiggy", "Event log from settlement didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from settlement didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), tokenId.toString(), "Event log from settlement didn't return correct tokenId")
+        //assert.strictEqual(result.logs[0].args.holderPayout.toString(), oraclePrice.toString(), "Event log from settlement didn't return correct holder payout")
+        //assert.strictEqual(result.logs[0].args.writerPayout.toString(), oraclePrice.toString(), "Event log from settlement didn't return correct writer payout")
+
+        eventHolderPayout = web3.utils.toBN(result.logs[0].args.holderPayout)
+        eventHolderPayout = web3.utils.toBN(result.logs[0].args.writerPayout)
+        // Put payout:
+          // if strike > settlement price | payout = strike - settlement price * lot size
+          payout = web3.utils.toBN(0)
+          if (strikePrice.gt(oraclePrice)) {
+            delta = strikePrice.sub(oraclePrice)
+            payout = delta.mul(decimals).mul(lotSize).div(web3.utils.toBN(100))
+          }
+          if (payout.gte(collateral)) {
+            payout = collateral
+          }
+
+        assert.strictEqual(result.logs[0].args.holderPayout.toString(), payout.toString(), "Event log from settlement didn't return correct holder payout")
+        assert.strictEqual(result.logs[0].args.writerPayout.toString(), collateral.sub(payout).toString(), "Event log from settlement didn't return correct writer payout")
       })
       //end test block
     });
@@ -3611,6 +4598,105 @@ contract ('SmartPiggies', function(accounts) {
         //put calculation for holder = payout
         assert.strictEqual(result[1].toString(), payout.toString(), "User balance did not update correctly")
         assert.strictEqual(result[1].toString(), "100000000000000000000", "Owner balance did not return 100*10^18")
+      })
+      //end test block
+    });
+
+    it("Should emit correct Settle Event when holder is paid full", function() {
+      collateralERC = tokenInstance.address
+      premiumERC = tokenInstance.address
+      dataResolverNow = resolverInstance.address
+      dataResolverAtExpiry = resolverInstance.address
+      collateral = web3.utils.toBN(100 * decimals)
+      lotSize = web3.utils.toBN(100)
+      strikePrice = web3.utils.toBN(28000)
+      expiry = 5000
+      isEuro = false
+      isPut = true
+      isRequest = false
+
+      startPrice = web3.utils.toBN(10000)
+      reservePrice = web3.utils.toBN(100)
+      auctionLength = 100
+      timeStep = web3.utils.toBN(1)
+      priceStep = web3.utils.toBN(100)
+
+      startBlock = web3.utils.toBN(0)
+      auctionPrice = web3.utils.toBN(0)
+
+      oracleFee = web3.utils.toBN('1000000000000000000')
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        //use last tokenId created
+        tokenId = result
+        return piggyInstance.startAuction(
+          tokenId,
+          startPrice,
+          reservePrice,
+          auctionLength,
+          timeStep,
+          priceStep,
+          {from: owner}
+        )
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "startAuction did not return true")
+
+        return sequentialPromise([
+          () => Promise.resolve(tokenInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(tokenInstance.approve(piggyInstance.address, collateral, {from: user01})),
+          () => Promise.resolve(piggyInstance.satisfyAuction(tokenId, {from: user01})),
+          () => Promise.resolve(linkInstance.mint(user01, collateral, {from: owner})),
+          () => Promise.resolve(linkInstance.approve(resolverInstance.address, collateral, {from: user01})),
+          () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenId, oracleFee, {from: user01})),
+        ])
+      })
+      .then(() => {
+        return piggyInstance.settlePiggy(tokenId, {from: owner})
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "settlePiggy did not return true")
+        //Settle Event
+        assert.strictEqual(result.logs[0].event, "SettlePiggy", "Event log from settlement didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from settlement didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), tokenId.toString(), "Event log from settlement didn't return correct tokenId")
+        //assert.strictEqual(result.logs[0].args.holderPayout.toString(), oraclePrice.toString(), "Event log from settlement didn't return correct holder payout")
+        //assert.strictEqual(result.logs[0].args.writerPayout.toString(), oraclePrice.toString(), "Event log from settlement didn't return correct writer payout")
+
+        eventHolderPayout = web3.utils.toBN(result.logs[0].args.holderPayout)
+        eventHolderPayout = web3.utils.toBN(result.logs[0].args.writerPayout)
+        // Put payout:
+          // if strike > settlement price | payout = strike - settlement price * lot size
+          payout = web3.utils.toBN(0)
+          if (strikePrice.gt(oraclePrice)) {
+            delta = strikePrice.sub(oraclePrice)
+            payout = delta.mul(decimals).mul(lotSize).div(web3.utils.toBN(100))
+          }
+          if (payout.gt(collateral)) {
+            payout = collateral
+          }
+          console.log("payout: ", payout.toString())
+          console.log("holder: ", result.logs[0].args.holderPayout.toString())
+        //assert.strictEqual(result.logs[0].args.holderPayout.toString(), collateral.sub(payout).toString(), "Event log from settlement didn't return correct holder payout")
+        //assert.strictEqual(result.logs[0].args.writerPayout.toString(), payout.toString(), "Event log from settlement didn't return correct writer payout")
       })
       //end test block
     });
@@ -5551,6 +6637,62 @@ contract ('SmartPiggies', function(accounts) {
         balanceBefore = web3.utils.toBN(result[0])
         assert.strictEqual(result[3].toString(), balanceBefore.add(collateral).toString(), "owner balance did not update correctly")
         assert.strictEqual(result[2].toString(), '', "getOwnedPiggies did not return empty")
+      })
+      //end test block
+    });
+
+    it("Should emit event when reclaimed", function() {
+      collateralERC = tokenInstance.address
+      premiumERC = tokenInstance.address
+      dataResolverNow = resolverInstance.address
+      dataResolverAtExpiry = resolverInstance.address
+      collateral = web3.utils.toBN(100 * decimals)
+      lotSize = 10
+      strikePrice = 28000
+      expiry = 5000
+      isEuro = false
+      isPut = true
+      isRequest = false
+
+      startPrice = web3.utils.toBN(10000)
+      reservePrice = web3.utils.toBN(100)
+      auctionLength = 100
+      timeStep = web3.utils.toBN(1)
+      priceStep = web3.utils.toBN(100)
+
+      return piggyInstance.createPiggy(
+        collateralERC,
+        premiumERC,
+        dataResolverNow,
+        dataResolverAtExpiry,
+        collateral,
+        lotSize,
+        strikePrice,
+        expiry,
+        isEuro,
+        isPut,
+        isRequest,
+        {from: owner}
+      )
+      .then(result => {
+        assert.isTrue(result.receipt.status, "create did not return true")
+        return piggyInstance.tokenId({from: owner});
+      })
+      .then(result => {
+        //use last tokenId created
+        tokenId = result
+        return piggyInstance.getOwnedPiggies(owner, {from: owner})
+      })
+      .then(result => {
+        assert.strictEqual(result.toString(), "1", "getOwnedPiggies did not return correctly")
+        return piggyInstance.reclaimAndBurn(tokenId, {from: owner})
+      })
+      .then(result => {
+        assert.isTrue(result.receipt.status, "reclaimAndBurn did not return true")
+        assert.strictEqual(result.logs[0].event, "ReclaimAndBurn", "Event log from reclaim didn't return correct event name")
+        assert.strictEqual(result.logs[0].args.from, owner, "Event log from reclaim didn't return correct sender")
+        assert.strictEqual(result.logs[0].args.tokenId.toString(), tokenId.toString(), "Event log from reclaim didn't return correct tokenId")
+        assert.isNotTrue(result.logs[0].args.RFP, "Event log from reclaim did not return false for RFP")
       })
       //end test block
     });


### PR DESCRIPTION
This will incorporate events into the contract. `updateRFP` needed a bit of refactoring to get an event and fix a bug with the `collateral` being updated rather than the `reqCollateral` param.