### PR TITLE
Update arbiter refactor

### DIFF
--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -1034,30 +1034,12 @@ contract SmartPiggies is UsingCooldown {
   /** Arbitration mechanisms
   */
 
-  function setArbiter(uint256 _tokenId, address _arbiter)
-    public
-    returns (bool)
-  {
-    // require valid token, valid non-zero address, that arbiter has not been set, that token is not on auction, that msg.sender is writer
-    require(piggies[_tokenId].addresses.writer == msg.sender, "you must be the writer to set an arbiter");
-    require(piggies[_tokenId].addresses.holder == msg.sender, "you must currently control the token to set an arbiter");
-    require(!auctions[_tokenId].auctionActive, "token cannot be on auction");
-    require(_arbiter != address(0), "arbiter address must not be zero address");
-    require(piggies[_tokenId].addresses.arbiter == address(0), "arbiter has already been set");
-
-    // update struct values
-    piggies[_tokenId].addresses.arbiter = _arbiter;
-
-    emit ArbiterSet(msg.sender, _arbiter, _tokenId);
-
-    return true;
-  }
-
   function updateArbiter(uint256 _tokenId, address _newArbiter)
     public
     returns (bool)
   {
     require(_newArbiter != address(0), "arbiter address must not be zero address");
+    require(!auctions[_tokenId].auctionActive, "token cannot be on auction");
     address _holder = piggies[_tokenId].addresses.holder;
     address _writer = piggies[_tokenId].addresses.writer;
     require(msg.sender == _holder || msg.sender == _writer, "only the writer or holder can propose a new arbiter");

--- a/test/arbiter-confirmation.js
+++ b/test/arbiter-confirmation.js
@@ -129,7 +129,7 @@ contract ('SmartPiggies', function(accounts) {
       .then(result => {
         assert.isTrue(result.receipt.status, "create piggy tx did not return true")
         tokenId = result.logs[0].args.ints[0]
-        return piggyInstance.setArbiter(tokenId, arbiter, {from: owner})
+        return piggyInstance.updateArbiter(tokenId, arbiter, {from: owner})
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "setArbiter did not return true")
@@ -180,7 +180,7 @@ contract ('SmartPiggies', function(accounts) {
       return sequentialPromise([
         () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
                 params[4],params[5],params[6],params[7],params[8],params[9],{from: owner})), //[0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, arbiter, {from: owner})), //[1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, arbiter, {from: owner})), //[1]
         () => Promise.resolve(piggyInstance.confirmArbiter(tokenId, {from: arbiter})), //[2]
         () => Promise.resolve(piggyInstance.getDetails(tokenId, {from: owner})), //[3]
         () => Promise.resolve(piggyInstance.startAuction(tokenId,startPrice,reservePrice,

--- a/test/arbitration.js
+++ b/test/arbitration.js
@@ -114,7 +114,7 @@ contract ('SmartPiggies', function(accounts) {
 
         /* get token id of created piggy */
         tokenId = result.logs[0].args[1][0].toString();
-        return piggyInstance.setArbiter(tokenId, user01);
+        return piggyInstance.updateArbiter(tokenId, user01);
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "set arbiter status did not return true");
@@ -161,7 +161,7 @@ contract ('SmartPiggies', function(accounts) {
 
       /* transaction should revert if sender is not owner */
       return expectedExceptionPromise(
-        () => piggyInstance.setArbiter(
+        () => piggyInstance.updateArbiter(
           tokenId, user01,
           {from: user01, gas: 8000000 }),
           3000000);
@@ -204,7 +204,7 @@ contract ('SmartPiggies', function(accounts) {
 
         /* transaction should revert if sender is not owner */
         return expectedExceptionPromise(
-          () => piggyInstance.setArbiter(
+          () => piggyInstance.updateArbiter(
             tokenId, user02,
             {from: user02, gas: 8000000 }),
             3000000);
@@ -237,7 +237,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: owner})), // [3]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: user01})), // [4]
@@ -279,7 +279,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
       ])
       .then(result => {
@@ -321,7 +321,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: owner})), // [3]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: user01})), // [4]
@@ -468,7 +468,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: owner})), // [3]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: user01})), // [4]
@@ -593,7 +593,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: owner})), // [3]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: user01})), // [4]
@@ -684,7 +684,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: owner})), // [3]
         () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user03, {from: user01})), // [4]
@@ -841,7 +841,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.getDetails(tokenId, {from: owner})), // [3]
       ])
@@ -881,7 +881,7 @@ contract ('SmartPiggies', function(accounts) {
           params[0],params[1],params[2],params[3],
           params[4],params[5],params[6],params[7],
           params[8], params[9], {from: owner})), // [0]
-        () => Promise.resolve(piggyInstance.setArbiter(tokenId, user02, {from: owner})), // [1]
+        () => Promise.resolve(piggyInstance.updateArbiter(tokenId, user02, {from: owner})), // [1]
         () => Promise.resolve(piggyInstance.transferFrom(owner, user01, tokenId, {from: owner})), // [2]
         () => Promise.resolve(piggyInstance.getDetails(tokenId, {from: owner})), // [3]
       ])
@@ -954,7 +954,7 @@ contract ('SmartPiggies', function(accounts) {
       .then(result => {
         //use last tokenId created
         tokenId = result
-        return piggyInstance.setArbiter(tokenId, user03, {from: owner});
+        return piggyInstance.updateArbiter(tokenId, user03, {from: owner});
       })
       .then(result => {
         assert.isTrue(result.receipt.status, "setArbiter did not return true");

--- a/test/updateRFP-during-auction.js
+++ b/test/updateRFP-during-auction.js
@@ -113,9 +113,10 @@ contract ('SmartPiggies', function(accounts) {
       ])
     });
   });
+
   describe("Test updateRFP during an auction", function() {
     // American Put RFP
-    it("Should be able to update an RFP during an auction", function() {
+    it("Should update an RFP during an auction for one writer", function() {
       collateralERC = tokenInstance.address
       dataResolver = resolverInstance.address
       collateral = web3.utils.toBN(100 * decimals)
@@ -276,13 +277,6 @@ contract ('SmartPiggies', function(accounts) {
         auctionPrice03 = result[26].logs[0].args.paidPremium
         auctionPrice04 = result[27].logs[0].args.paidPremium
         auctionPrice05 = result[28].logs[0].args.paidPremium
-        /**
-        auctionPrice01 = result[24].logs[1].args.paidPremium
-        auctionPrice02 = result[25].logs[1].args.paidPremium
-        auctionPrice03 = result[26].logs[1].args.paidPremium
-        auctionPrice04 = result[27].logs[1].args.paidPremium
-        auctionPrice05 = result[28].logs[1].args.paidPremium
-        **/
 
         auctionProceeds = auctionProceeds.add(auctionPrice01).add(auctionPrice02)
           .add(auctionPrice03).add(auctionPrice04).add(auctionPrice05)
@@ -312,12 +306,233 @@ contract ('SmartPiggies', function(accounts) {
         // if strike > settlement price | payout = strike - settlement price * lot size
         oneHundred = web3.utils.toBN(100)
 
-        //users are now writers 
+        //users are now writers
         payouts.push(updateStrikePrice.sub(proposedPrices[0]).mul(decimals).mul(updateLotSize).div(oneHundred))
         serviceFees.push(payouts[0].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
         assert.strictEqual(erc20BalanceUser01.toString(), updateCollateral.sub(payouts[0]).toString(), "user01's balance did not return correctly");
 
-/**
+        payouts.push(updateStrikePrice.sub(proposedPrices[1]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[1].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser02.toString(), updateCollateral.sub(payouts[1]).toString(), "user02's balance did not return correctly");
+
+        payouts.push(updateStrikePrice.sub(proposedPrices[2]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[2].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser03.toString(), updateCollateral.sub(payouts[2]).toString(), "user03's balance did not return correctly");
+
+        payouts.push(updateStrikePrice.sub(proposedPrices[3]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[3].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser04.toString(), updateCollateral.sub(payouts[3]).toString(), "user04's balance did not return correctly");
+
+        payouts.push(updateStrikePrice.sub(proposedPrices[4]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[4].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser05.toString(), updateCollateral.sub(payouts[4]).toString(), "user05's balance did not return correctly");
+
+        //totalPayout = payouts[0].add(payouts[1]).add(payouts[2]).add(payouts[3]).add(payouts[4])
+        payouts.forEach(e => totalPayout = totalPayout.add(e))
+        serviceFees.forEach(e => totalFees = totalFees.add(e))
+        assert.strictEqual(erc20BalanceOwner.toString(), totalPayout.sub(totalFees).toString(), "writer balance did not return correctly")
+
+        assert.strictEqual(erc20BalanceArbiter.toString(), "0", "arbiter's balance did not return correctly");
+
+      })
+    }); //end test
+
+    // American Put RFP
+    it("Should update an RFP during an auction by many users", function() {
+      collateralERC = tokenInstance.address
+      dataResolver = resolverInstance.address
+      collateral = web3.utils.toBN(100 * decimals)
+      updateCollateral = web3.utils.toBN(20 * decimals)
+      lotSize = 10
+      updateLotSize = web3.utils.toBN(5)
+      strikePrice = 28000
+      updateStrikePrice = web3.utils.toBN(29000)
+      expiry = web3.utils.toBN(500)
+      isEuro = false
+      isPut = true
+      isRequest = true //create RFP
+
+      startPrice = web3.utils.toBN(10000)
+      reservePrice = web3.utils.toBN(100)
+      auctionLength = 100
+      timeStep = web3.utils.toBN(1)
+      priceStep = web3.utils.toBN(100)
+
+      startBlock = web3.utils.toBN(0)
+      auctionPrice = web3.utils.toBN(0)
+
+      oracleFee = web3.utils.toBN('1000000000000000000')
+
+      serviceFee = web3.utils.toBN(0)
+
+      tokenIds = [1,2,3,4,5]
+      numOfTokens = web3.utils.toBN(tokenIds.length)
+
+      let originalBalanceOwner, originalBalanceUser01
+      let auctionProceeds = web3.utils.toBN(0)
+      let auctionPrice01,auctionPrice02,auctionPrice03,auctionPrice04,auctionPrice05
+      let totalCollateral = web3.utils.toBN(0)
+      let payout = web3.utils.toBN(0)
+      let totalPayout = web3.utils.toBN(0)
+      let totalFees = web3.utils.toBN(0)
+
+      let proposedPrices = [
+            web3.utils.toBN(28912),
+            web3.utils.toBN(28929),
+            web3.utils.toBN(28953),
+            web3.utils.toBN(28976),
+            web3.utils.toBN(28991)
+          ]
+      let payouts = []
+      let serviceFees = []
+
+      params = [collateralERC,addr123,addr00,collateral,
+        lotSize,strikePrice,expiry,isEuro,isPut,isRequest]
+
+      updateParams = [addr00,dataResolver,arbiter,updateCollateral,
+        updateLotSize,updateStrikePrice,expiry,isEuro,isPut]
+
+      return sequentialPromise([
+        () => Promise.resolve(tokenInstance.balanceOf(owner, {from: owner})), //[0]
+        () => Promise.resolve(tokenInstance.balanceOf(user01, {from: user01})), //[1]
+
+        () => Promise.resolve(piggyInstance.getERC20Balance(owner, tokenInstance.address, {from: owner})), //[2]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user01, tokenInstance.address, {from: owner})), //[3]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user02, tokenInstance.address, {from: owner})), //[4]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user03, tokenInstance.address, {from: owner})), //[5]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user04, tokenInstance.address, {from: owner})), //[6]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user05, tokenInstance.address, {from: owner})), //[7]
+        () => Promise.resolve(piggyInstance.getERC20Balance(arbiter, tokenInstance.address, {from: owner})), //[8]
+
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: user01})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: user02})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: user03})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: user04})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: user05})),
+
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[0],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: user01})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[1],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: user02})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[2],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: user03})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[3],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: user04})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[4],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: user05})),
+
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[0],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: user01})), //[19]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[1],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: user02})), //[20]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[2],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: user03})), //[21]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[3],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: user04})), //[22]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[4],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: user05})), //[23]
+
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[0], {from: owner})), //[24]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[1], {from: owner})), //[25]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[2], {from: owner})), //[26]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[3], {from: owner})), //[27]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[4], {from: owner})), //[28]
+
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[0], oracleFee, {from: user01})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[1], oracleFee, {from: user02})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[2], oracleFee, {from: user03})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[3], oracleFee, {from: user04})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[4], oracleFee, {from: user05})),
+
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[0], proposedPrices[0], {from: user01})), //[34]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[0], proposedPrices[0], {from: arbiter})), //[35]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[1], proposedPrices[1], {from: user02})), //[36]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[1], proposedPrices[1], {from: arbiter})), //[37]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[2], proposedPrices[2], {from: user03})), //[38]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[2], proposedPrices[2], {from: arbiter})), //[39]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[3], proposedPrices[3], {from: user04})), //[40]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[3], proposedPrices[3], {from: arbiter})), //[41]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[4], proposedPrices[4], {from: user05})), //[42]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[4], proposedPrices[4], {from: arbiter})), //[43]
+
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[0], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[1], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[2], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[3], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[4], {from: owner})),
+
+        () => Promise.resolve(piggyInstance.getERC20Balance(owner, tokenInstance.address, {from: owner})), //[49]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user01, tokenInstance.address, {from: owner})), //[50]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user02, tokenInstance.address, {from: owner})), //[51]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user03, tokenInstance.address, {from: owner})), //[52]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user04, tokenInstance.address, {from: owner})), //[53]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user05, tokenInstance.address, {from: owner})), //[54]
+        () => Promise.resolve(piggyInstance.getERC20Balance(arbiter, tokenInstance.address, {from: owner})), //[55]
+      ])
+      .then(result => {
+
+        // ERC20 balance accounting should be collateral from all piggies
+        originalBalanceOwner = result[0]
+        originalBalanceUser01 = result[1]
+
+        originalERC20BalanceOwner = result[2]
+        originalERC20BalanceUser01 = result[3]
+        originalERC20BalanceUser02 = result[4]
+        originalERC20BalanceUser03 = result[5]
+        originalERC20BalanceUser04 = result[6]
+        originalERC20BalanceUser05 = result[7]
+        originalERC20BalanceArbiter = result[8]
+
+        //for RFP auction, only one event, as transfer doesn't take place
+        auctionPrice01 = result[24].logs[0].args.paidPremium
+        auctionPrice02 = result[25].logs[0].args.paidPremium
+        auctionPrice03 = result[26].logs[0].args.paidPremium
+        auctionPrice04 = result[27].logs[0].args.paidPremium
+        auctionPrice05 = result[28].logs[0].args.paidPremium
+
+        auctionProceeds = auctionProceeds.add(auctionPrice01).add(auctionPrice02)
+          .add(auctionPrice03).add(auctionPrice04).add(auctionPrice05)
+
+        erc20BalanceOwner = result[49]
+        erc20BalanceUser01 = result[50]
+        erc20BalanceUser02 = result[51]
+        erc20BalanceUser03 = result[52]
+        erc20BalanceUser04 = result[53]
+        erc20BalanceUser05 = result[54]
+        erc20BalanceArbiter = result[55]
+
+        // token balance at token contract should be initial supply minted for user
+        assert.strictEqual(originalBalanceOwner.toString(), supply.toString(), "owner's original token balance did not return correctly")
+        assert.strictEqual(originalBalanceUser01.toString(), supply.toString(), "user01's original token balance did not return correctly")
+
+        // token balance at smartpiggies contract should start at zero
+        assert.strictEqual(originalERC20BalanceOwner.toString(), "0", "owner's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser01.toString(), "0", "user01's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser02.toString(), "0", "user02's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser03.toString(), "0", "user03's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser04.toString(), "0", "user04's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser05.toString(), "0", "user05's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceArbiter.toString(), "0", "arbiter's original smartpiggies erc20 balance did not return zero")
+
+        // calculate put payout:
+        // if strike > settlement price | payout = strike - settlement price * lot size
+        oneHundred = web3.utils.toBN(100)
+
+        //users are now writers
+        payouts.push(updateStrikePrice.sub(proposedPrices[0]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[0].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser01.toString(), payouts[0].sub(serviceFees[0]).toString(), "user01's balance did not return correctly");
+
         payouts.push(updateStrikePrice.sub(proposedPrices[1]).mul(decimals).mul(updateLotSize).div(oneHundred))
         serviceFees.push(payouts[1].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
         assert.strictEqual(erc20BalanceUser02.toString(), payouts[1].sub(serviceFees[1]).toString(), "user02's balance did not return correctly");
@@ -328,18 +543,16 @@ contract ('SmartPiggies', function(accounts) {
 
         payouts.push(updateStrikePrice.sub(proposedPrices[3]).mul(decimals).mul(updateLotSize).div(oneHundred))
         serviceFees.push(payouts[3].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
-        assert.strictEqual(erc20BalanceUser04.toString(), payouts[3].sub(serviceFees[3]).toString(), "user04's balance did not return correctly");
+        assert.strictEqual(erc20BalanceUser04.toString(), payouts[3].sub(serviceFees[3]).toString().toString(), "user04's balance did not return correctly");
 
         payouts.push(updateStrikePrice.sub(proposedPrices[4]).mul(decimals).mul(updateLotSize).div(oneHundred))
         serviceFees.push(payouts[4].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
-        assert.strictEqual(erc20BalanceUser05.toString(), payouts[4].sub(serviceFees[4]).toString(), "user05's balance did not return correctly");
+        assert.strictEqual(erc20BalanceUser05.toString(), payouts[4].sub(serviceFees[4]).toString().toString(), "user05's balance did not return correctly");
 
-
-        totalCollateral = collateral.mul(numOfTokens)
-        totalPayout = payouts[0].add(payouts[1]).add(payouts[2]).add(payouts[3]).add(payouts[4])
+        payouts.forEach(e => totalPayout = totalPayout.add(e))
+        totalCollateral = updateCollateral.mul(numOfTokens)
         assert.strictEqual(erc20BalanceOwner.toString(), totalCollateral.sub(totalPayout).toString(), "writer balance did not return correctly")
 
-**/
         assert.strictEqual(erc20BalanceArbiter.toString(), "0", "arbiter's balance did not return correctly");
 
       })

--- a/test/updateRFP-during-auction.js
+++ b/test/updateRFP-during-auction.js
@@ -1,0 +1,350 @@
+Promise = require("bluebird");
+var StableToken = artifacts.require("./StableToken.sol");
+var TestnetLINK = artifacts.require("./TestnetLINK.sol");
+var SmartPiggies = artifacts.require("./SmartPiggies.sol");
+var Resolver = artifacts.require("./ResolverSelfReturn.sol");
+
+const expectedExceptionPromise = require("../utils/expectedException.js");
+const sequentialPromise = require("../utils/sequentialPromise.js");
+web3.eth.makeSureHasAtLeast = require("../utils/makeSureHasAtLeast.js");
+web3.eth.makeSureAreUnlocked = require("../utils/makeSureAreUnlocked.js");
+web3.eth.getTransactionReceiptMined = require("../utils/getTransactionReceiptMined.js");
+
+if (typeof web3.eth.getAccountsPromise === "undefined") {
+    Promise.promisifyAll(web3.eth, { suffix: "Promise" });
+}
+
+contract ('SmartPiggies', function(accounts) {
+
+  var tokenInstance;
+  var linkInstance;
+  var piggyInstance;
+  var resolverInstanceZero;
+  var resolverInstanceBad;
+  var owner = accounts[0];
+  var user01 = accounts[1];
+  var user02 = accounts[2];
+  var user03 = accounts[3];
+  var user04 = accounts[4];
+  var user05 = accounts[5];
+  var arbiter = accounts[6];
+  var feeAddress = accounts[7];
+  var addr00 = "0x0000000000000000000000000000000000000000";
+  var addr123 = "0x1230000000000000000000000000000000000000";
+  var decimal = 18;
+  //multiply a BN
+  //var aNum = web3.utils.toBN(decimals).mul(web3.utils.toBN('1000'))
+  var decimals = web3.utils.toBN(Math.pow(10,decimal));
+  var supply = web3.utils.toWei("1000", "ether");
+  var approveAmount = web3.utils.toWei("100", "ether");
+  var exchangeRate = 1;
+  var dataSource = 'NASDAQ';
+  var underlying = 'SPY';
+  var oracleService = 'Self';
+  var endpoint = 'https://www.nasdaq.com/symbol/spy';
+  var path = '';
+  var oracleTokenAddress;
+  var oraclePrice = web3.utils.toBN(0); // return price from oracle
+
+  /* default feePercent param = 50 */
+  const DEFAULT_FEE_PERCENT = web3.utils.toBN(50);
+  /* default feePercent param = 10,000 */
+  const DEFAULT_FEE_RESOLUTION = web3.utils.toBN(10000);
+
+  beforeEach(function() {
+    //console.log(JSON.stringify("symbol: " + result, null, 4));
+    return StableToken.new({from: owner})
+    .then(instance => {
+      tokenInstance = instance;
+      return TestnetLINK.new({from: owner});
+    })
+    .then(instance => {
+      linkInstance = instance;
+      oracleTokenAddress = linkInstance.address;
+      return Resolver.new(
+        dataSource,
+        underlying,
+        oracleService,
+        endpoint,
+        path,
+        oracleTokenAddress,
+        oraclePrice,
+        {from: owner});
+    })
+    .then(instance => {
+      resolverInstance = instance;
+      return SmartPiggies.new({from: owner, gas: 8000000, gasPrice: 1100000000});
+    })
+    .then(instance => {
+      piggyInstance = instance;
+
+      /* setup housekeeping */
+      return sequentialPromise([
+        () => Promise.resolve(tokenInstance.mint(owner, supply, {from: owner})),
+        () => Promise.resolve(tokenInstance.mint(user01, supply, {from: owner})),
+        () => Promise.resolve(tokenInstance.mint(user02, supply, {from: owner})),
+        () => Promise.resolve(tokenInstance.mint(user03, supply, {from: owner})),
+        () => Promise.resolve(tokenInstance.mint(user04, supply, {from: owner})),
+        () => Promise.resolve(tokenInstance.mint(user05, supply, {from: owner})),
+
+        () => Promise.resolve(linkInstance.mint(owner, supply, {from: owner})),
+        () => Promise.resolve(linkInstance.mint(user01, supply, {from: owner})),
+        () => Promise.resolve(linkInstance.mint(user02, supply, {from: owner})),
+        () => Promise.resolve(linkInstance.mint(user03, supply, {from: owner})),
+        () => Promise.resolve(linkInstance.mint(user04, supply, {from: owner})),
+        () => Promise.resolve(linkInstance.mint(user05, supply, {from: owner})),
+
+        () => Promise.resolve(tokenInstance.approve(piggyInstance.address, approveAmount, {from: owner})),
+        () => Promise.resolve(tokenInstance.approve(piggyInstance.address, approveAmount, {from: user01})),
+        () => Promise.resolve(tokenInstance.approve(piggyInstance.address, approveAmount, {from: user02})),
+        () => Promise.resolve(tokenInstance.approve(piggyInstance.address, approveAmount, {from: user03})),
+        () => Promise.resolve(tokenInstance.approve(piggyInstance.address, approveAmount, {from: user04})),
+        () => Promise.resolve(tokenInstance.approve(piggyInstance.address, approveAmount, {from: user05})),
+
+        () => Promise.resolve(linkInstance.approve(resolverInstance.address, approveAmount, {from: owner})),
+        () => Promise.resolve(linkInstance.approve(resolverInstance.address, approveAmount, {from: user01})),
+        () => Promise.resolve(linkInstance.approve(resolverInstance.address, approveAmount, {from: user02})),
+        () => Promise.resolve(linkInstance.approve(resolverInstance.address, approveAmount, {from: user03})),
+        () => Promise.resolve(linkInstance.approve(resolverInstance.address, approveAmount, {from: user04})),
+        () => Promise.resolve(linkInstance.approve(resolverInstance.address, approveAmount, {from: user05})),
+
+        () => Promise.resolve(piggyInstance.setFeeAddress(feeAddress, {from: owner})),
+        () => Promise.resolve(piggyInstance.setCooldown(3, {from: owner}))
+      ])
+    });
+  });
+  describe("Test updateRFP during an auction", function() {
+    // American Put RFP
+    it("Should be able to update an RFP during an auction", function() {
+      collateralERC = tokenInstance.address
+      dataResolver = resolverInstance.address
+      collateral = web3.utils.toBN(100 * decimals)
+      updateCollateral = web3.utils.toBN(20 * decimals)
+      lotSize = 10
+      updateLotSize = web3.utils.toBN(5)
+      strikePrice = 28000
+      updateStrikePrice = web3.utils.toBN(29000)
+      expiry = web3.utils.toBN(500)
+      isEuro = false
+      isPut = true
+      isRequest = true //create RFP
+
+      startPrice = web3.utils.toBN(10000)
+      reservePrice = web3.utils.toBN(100)
+      auctionLength = 100
+      timeStep = web3.utils.toBN(1)
+      priceStep = web3.utils.toBN(100)
+
+      startBlock = web3.utils.toBN(0)
+      auctionPrice = web3.utils.toBN(0)
+
+      oracleFee = web3.utils.toBN('1000000000000000000')
+
+      serviceFee = web3.utils.toBN(0)
+
+      tokenIds = [1,2,3,4,5]
+      numOfTokens = web3.utils.toBN(tokenIds.length)
+
+      let originalBalanceOwner, originalBalanceUser01
+      let auctionProceeds = web3.utils.toBN(0)
+      let auctionPrice01,auctionPrice02,auctionPrice03,auctionPrice04,auctionPrice05
+      let totalCollateral = web3.utils.toBN(0)
+      let payout = web3.utils.toBN(0)
+      let totalPayout = web3.utils.toBN(0)
+      let totalFees = web3.utils.toBN(0)
+
+      let proposedPrices = [
+            web3.utils.toBN(28912),
+            web3.utils.toBN(28929),
+            web3.utils.toBN(28953),
+            web3.utils.toBN(28976),
+            web3.utils.toBN(28991)
+          ]
+      let payouts = []
+      let serviceFees = []
+
+      params = [collateralERC,addr123,addr00,collateral,
+        lotSize,strikePrice,expiry,isEuro,isPut,isRequest]
+
+      updateParams = [addr00,dataResolver,arbiter,updateCollateral,
+        updateLotSize,updateStrikePrice,expiry,isEuro,isPut]
+
+      return sequentialPromise([
+        () => Promise.resolve(tokenInstance.balanceOf(owner, {from: owner})), //[0]
+        () => Promise.resolve(tokenInstance.balanceOf(user01, {from: user01})), //[1]
+
+        () => Promise.resolve(piggyInstance.getERC20Balance(owner, tokenInstance.address, {from: owner})), //[2]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user01, tokenInstance.address, {from: owner})), //[3]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user02, tokenInstance.address, {from: owner})), //[4]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user03, tokenInstance.address, {from: owner})), //[5]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user04, tokenInstance.address, {from: owner})), //[6]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user05, tokenInstance.address, {from: owner})), //[7]
+        () => Promise.resolve(piggyInstance.getERC20Balance(arbiter, tokenInstance.address, {from: owner})), //[8]
+
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: owner})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: owner})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: owner})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: owner})),
+        () => Promise.resolve(piggyInstance.createPiggy(params[0],params[1],params[2],params[3],
+                params[4],params[5],params[6],params[7],params[8],params[9],{from: owner})),
+
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[0],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: owner})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[1],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: owner})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[2],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: owner})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[3],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: owner})),
+        () => Promise.resolve(piggyInstance.startAuction(tokenIds[4],startPrice,reservePrice,
+                auctionLength,timeStep,priceStep,{from: owner})),
+
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[0],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: owner})), //[19]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[1],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: owner})), //[20]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[2],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: owner})), //[21]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[3],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: owner})), //[22]
+        () => Promise.resolve(piggyInstance.updateRFP(tokenIds[4],updateParams[0],updateParams[1],
+                updateParams[2],updateParams[3],updateParams[4],updateParams[5],updateParams[6],
+                updateParams[7],updateParams[8],{from: owner})), //[23]
+
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[0], {from: user01})), //[24]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[1], {from: user02})), //[25]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[2], {from: user03})), //[26]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[3], {from: user04})), //[27]
+        () => Promise.resolve(piggyInstance.satisfyAuction(tokenIds[4], {from: user05})), //[28]
+
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[0], oracleFee, {from: owner})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[1], oracleFee, {from: owner})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[2], oracleFee, {from: owner})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[3], oracleFee, {from: owner})),
+        () => Promise.resolve(piggyInstance.requestSettlementPrice(tokenIds[4], oracleFee, {from: owner})),
+
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[0], proposedPrices[0], {from: user01})), //[34]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[0], proposedPrices[0], {from: arbiter})), //[35]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[1], proposedPrices[1], {from: user02})), //[36]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[1], proposedPrices[1], {from: arbiter})), //[37]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[2], proposedPrices[2], {from: user03})), //[38]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[2], proposedPrices[2], {from: arbiter})), //[39]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[3], proposedPrices[3], {from: user04})), //[40]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[3], proposedPrices[3], {from: arbiter})), //[41]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[4], proposedPrices[4], {from: user05})), //[42]
+        () => Promise.resolve(piggyInstance.thirdPartyArbitrationSettlement(tokenIds[4], proposedPrices[4], {from: arbiter})), //[43]
+
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[0], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[1], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[2], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[3], {from: owner})),
+        () => Promise.resolve(piggyInstance.settlePiggy(tokenIds[4], {from: owner})),
+
+        () => Promise.resolve(piggyInstance.getERC20Balance(owner, tokenInstance.address, {from: owner})), //[49]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user01, tokenInstance.address, {from: owner})), //[50]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user02, tokenInstance.address, {from: owner})), //[51]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user03, tokenInstance.address, {from: owner})), //[52]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user04, tokenInstance.address, {from: owner})), //[53]
+        () => Promise.resolve(piggyInstance.getERC20Balance(user05, tokenInstance.address, {from: owner})), //[54]
+        () => Promise.resolve(piggyInstance.getERC20Balance(arbiter, tokenInstance.address, {from: owner})), //[55]
+      ])
+      .then(result => {
+
+        // ERC20 balance accounting should be collateral from all piggies
+        originalBalanceOwner = result[0]
+        originalBalanceUser01 = result[1]
+
+        originalERC20BalanceOwner = result[2]
+        originalERC20BalanceUser01 = result[3]
+        originalERC20BalanceUser02 = result[4]
+        originalERC20BalanceUser03 = result[5]
+        originalERC20BalanceUser04 = result[6]
+        originalERC20BalanceUser05 = result[7]
+        originalERC20BalanceArbiter = result[8]
+
+        //for RFP auction, only one event, as transfer doesn't take place
+        auctionPrice01 = result[24].logs[0].args.paidPremium
+        auctionPrice02 = result[25].logs[0].args.paidPremium
+        auctionPrice03 = result[26].logs[0].args.paidPremium
+        auctionPrice04 = result[27].logs[0].args.paidPremium
+        auctionPrice05 = result[28].logs[0].args.paidPremium
+        /**
+        auctionPrice01 = result[24].logs[1].args.paidPremium
+        auctionPrice02 = result[25].logs[1].args.paidPremium
+        auctionPrice03 = result[26].logs[1].args.paidPremium
+        auctionPrice04 = result[27].logs[1].args.paidPremium
+        auctionPrice05 = result[28].logs[1].args.paidPremium
+        **/
+
+        auctionProceeds = auctionProceeds.add(auctionPrice01).add(auctionPrice02)
+          .add(auctionPrice03).add(auctionPrice04).add(auctionPrice05)
+
+        erc20BalanceOwner = result[49]
+        erc20BalanceUser01 = result[50]
+        erc20BalanceUser02 = result[51]
+        erc20BalanceUser03 = result[52]
+        erc20BalanceUser04 = result[53]
+        erc20BalanceUser05 = result[54]
+        erc20BalanceArbiter = result[55]
+
+        // token balance at token contract should be initial supply minted for user
+        assert.strictEqual(originalBalanceOwner.toString(), supply.toString(), "owner's original token balance did not return correctly")
+        assert.strictEqual(originalBalanceUser01.toString(), supply.toString(), "user01's original token balance did not return correctly")
+
+        // token balance at smartpiggies contract should start at zero
+        assert.strictEqual(originalERC20BalanceOwner.toString(), "0", "owner's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser01.toString(), "0", "user01's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser02.toString(), "0", "user02's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser03.toString(), "0", "user03's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser04.toString(), "0", "user04's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceUser05.toString(), "0", "user05's original smartpiggies erc20 balance did not return zero")
+        assert.strictEqual(originalERC20BalanceArbiter.toString(), "0", "arbiter's original smartpiggies erc20 balance did not return zero")
+
+        // calculate put payout:
+        // if strike > settlement price | payout = strike - settlement price * lot size
+        oneHundred = web3.utils.toBN(100)
+
+        //users are now writers 
+        payouts.push(updateStrikePrice.sub(proposedPrices[0]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[0].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser01.toString(), updateCollateral.sub(payouts[0]).toString(), "user01's balance did not return correctly");
+
+/**
+        payouts.push(updateStrikePrice.sub(proposedPrices[1]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[1].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser02.toString(), payouts[1].sub(serviceFees[1]).toString(), "user02's balance did not return correctly");
+
+        payouts.push(updateStrikePrice.sub(proposedPrices[2]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[2].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser03.toString(), payouts[2].sub(serviceFees[2]).toString(), "user03's balance did not return correctly");
+
+        payouts.push(updateStrikePrice.sub(proposedPrices[3]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[3].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser04.toString(), payouts[3].sub(serviceFees[3]).toString(), "user04's balance did not return correctly");
+
+        payouts.push(updateStrikePrice.sub(proposedPrices[4]).mul(decimals).mul(updateLotSize).div(oneHundred))
+        serviceFees.push(payouts[4].mul(DEFAULT_FEE_PERCENT).div(DEFAULT_FEE_RESOLUTION))
+        assert.strictEqual(erc20BalanceUser05.toString(), payouts[4].sub(serviceFees[4]).toString(), "user05's balance did not return correctly");
+
+
+        totalCollateral = collateral.mul(numOfTokens)
+        totalPayout = payouts[0].add(payouts[1]).add(payouts[2]).add(payouts[3]).add(payouts[4])
+        assert.strictEqual(erc20BalanceOwner.toString(), totalCollateral.sub(totalPayout).toString(), "writer balance did not return correctly")
+
+**/
+        assert.strictEqual(erc20BalanceArbiter.toString(), "0", "arbiter's balance did not return correctly");
+
+      })
+    }); //end test
+
+  }); //end describe
+
+}); //end test suite


### PR DESCRIPTION
Delete setArbiter now that it is possible to set the arbiter on create. On an update function is needed. Refactor `updateArbiter` to include a require that a piggy cannot be on auction during an arbiter address update