### PR TITLE
restructure uintDetails storage layout

### DIFF
--- a/contracts/SmartPiggies.sol
+++ b/contracts/SmartPiggies.sol
@@ -270,11 +270,11 @@ contract SmartPiggies is UsingCooldown {
     uint256 expiry;
     uint256 settlementPrice; //04.20.20 oil price is negative :9
     uint256 reqCollateral;
-    uint8 collateralDecimals;  // store decimals from ERC-20 contract
     uint256 arbitrationLock;
     uint256 writerProposedPrice; //can propose negative price
     uint256 holderProposedPrice; //can propose negative price
     uint256 arbiterProposedPrice; //can propose negative price
+    uint8 collateralDecimals;  // store decimals from ERC-20 contract
     uint8 rfpNonce;
   }
 


### PR DESCRIPTION
refactor storage layout to optimize memory layout of contract. Oddly moving the smaller data types to the beginning of the structs made the contract size larger, moving the smaller types to the end of the struct layout does make a difference. Moved the collateralDecimals to second to last in uintDetails next to the rfpNonce, both uint8. This saves 7 bytes. So why not. Unit tests use the names of the array elements rather than the index, so none of the tests broke, but any introspection using index location will need to account for this change. 